### PR TITLE
Add tranche manifest for multi-session ufs2arco builds

### DIFF
--- a/scripts/regrid_static_vars.py
+++ b/scripts/regrid_static_vars.py
@@ -12,7 +12,7 @@ Usage:
         --static-file /home/mflora/graf-ai/grafai/data/rpm4km.static.nc \
         --weight-file /home/mflora/graf-reforecast-conus-interp/data/graf_to_grafconus_4km_weights.nc \
         --reference-zarr /grafrr/2004010112_27/mpasout_15m.zarr \
-        --output /home/mflora/graf-reforecast-conus-interp/data/GRAF_CONUS_static_regridded.nc
+        --output /home/mflora/graf-ai/grafai/data/graf_regridded_static.nc
 
 Author: monte-flora
 """

--- a/tests/test_tranches.py
+++ b/tests/test_tranches.py
@@ -1,0 +1,167 @@
+"""Unit tests for the tranche manifest helpers (ufs2arco.tranches).
+
+These cover the pure-Python helpers (no source instantiation, no MPI).
+End-to-end multi-session builds are validated via the smoke recipe at
+graf-ai/grafai/datasets/graf-regridded-oklahoma/oklahoma-tranche-smoke.yaml.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ufs2arco import tranches
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+def _write_manifest(tmp_path, total_batches=20, num_tranches=4, batch_size=8):
+    """Write a synthetic manifest by hand (skipping init_template, which would
+    require instantiating a real source)."""
+    base = total_batches // num_tranches
+    rem = total_batches % num_tranches
+    cursor = 0
+    tr_list = []
+    for i in range(num_tranches):
+        size = base + (1 if i < rem else 0)
+        tr_list.append({
+            "id": i, "start": cursor, "stop": cursor + size,
+            "description": f"tranche {i}", "state": "pending",
+            "samples_processed": None, "started_utc": None, "finished_utc": None,
+        })
+        cursor += size
+    manifest = {
+        "zarr": str(tmp_path / "fake.zarr"),
+        "config_hash": "abc123",
+        "total_samples": total_batches * batch_size,
+        "total_batches": total_batches,
+        "batch_size": batch_size,
+        "created_utc": "2026-01-01T00:00:00Z",
+        "tranches": tr_list,
+    }
+    path = tmp_path / "fake.tranches.yaml"
+    tranches.save_manifest(str(path), manifest)
+    return str(path), manifest
+
+
+# ----------------------------------------------------------------------
+# Tests
+# ----------------------------------------------------------------------
+def test_default_tranche_path_appends_suffix():
+    assert tranches.default_tranche_path("/x/y/build.yaml") == "/x/y/build.tranches.yaml"
+    assert tranches.default_tranche_path("recipe.yml") == "recipe.tranches.yaml"
+
+
+def test_hash_recipe_stable_across_reads(tmp_path):
+    p = tmp_path / "r.yaml"
+    p.write_text("foo: bar\n")
+    h1 = tranches.hash_recipe(str(p))
+    h2 = tranches.hash_recipe(str(p))
+    assert h1 == h2
+    assert len(h1) == 64  # sha256 hex
+
+
+def test_hash_changes_when_yaml_changes(tmp_path):
+    p = tmp_path / "r.yaml"
+    p.write_text("foo: bar\n")
+    h1 = tranches.hash_recipe(str(p))
+    p.write_text("foo: bar\n# trivial change\n")
+    h2 = tranches.hash_recipe(str(p))
+    assert h1 != h2
+
+
+def test_save_then_load_roundtrip(tmp_path):
+    path, m_in = _write_manifest(tmp_path)
+    m_out = tranches.load_manifest(path)
+    assert m_out["total_batches"] == m_in["total_batches"]
+    assert m_out["batch_size"] == m_in["batch_size"]
+    assert len(m_out["tranches"]) == 4
+
+
+def test_load_with_recipe_hash_drift_detected(tmp_path):
+    """If the recipe yaml's hash differs from the manifest's stored hash,
+    load_manifest must error with both hashes in the message."""
+    recipe = tmp_path / "r.yaml"
+    recipe.write_text("foo: bar\n")
+    path, _ = _write_manifest(tmp_path)
+    # Manifest's config_hash is the synthetic 'abc123', recipe's is real sha256.
+    with pytest.raises(RuntimeError, match="Recipe hash mismatch"):
+        tranches.load_manifest(path, recipe_path=str(recipe))
+
+
+def test_load_with_recipe_hash_match_succeeds(tmp_path):
+    recipe = tmp_path / "r.yaml"
+    recipe.write_text("foo: bar\n")
+    actual_hash = tranches.hash_recipe(str(recipe))
+    path, m = _write_manifest(tmp_path)
+    m["config_hash"] = actual_hash
+    tranches.save_manifest(path, m)
+    # Should not raise.
+    tranches.load_manifest(path, recipe_path=str(recipe))
+
+
+def test_get_tranche_returns_dict(tmp_path):
+    path, _ = _write_manifest(tmp_path)
+    m = tranches.load_manifest(path)
+    tr = tranches.get_tranche(m, 2)
+    assert tr["id"] == 2
+    assert tr["start"] == 10  # 20 batches / 4 tranches; even split = [0,5,10,15]
+
+
+def test_get_tranche_missing_id_raises(tmp_path):
+    path, _ = _write_manifest(tmp_path)
+    m = tranches.load_manifest(path)
+    with pytest.raises(KeyError):
+        tranches.get_tranche(m, 99)
+
+
+def test_update_state_persists_changes(tmp_path):
+    path, _ = _write_manifest(tmp_path)
+    tranches.update_state(path, 1, state="done", finished_utc="2026-01-02T00:00:00Z")
+    m = tranches.load_manifest(path)
+    tr = tranches.get_tranche(m, 1)
+    assert tr["state"] == "done"
+    assert tr["finished_utc"] == "2026-01-02T00:00:00Z"
+    # Other tranches untouched
+    assert tranches.get_tranche(m, 0)["state"] == "pending"
+
+
+def test_verify_complete_reports_pending(tmp_path):
+    path, _ = _write_manifest(tmp_path)
+    m = tranches.load_manifest(path)
+    ok, pending = tranches.verify_complete(m)
+    assert not ok
+    assert pending == [0, 1, 2, 3]
+
+    for i in range(4):
+        tranches.update_state(path, i, state="done")
+    m = tranches.load_manifest(path)
+    ok, pending = tranches.verify_complete(m)
+    assert ok
+    assert pending == []
+
+
+def test_atomic_save_uses_rename(tmp_path):
+    """save_manifest writes to a .tmp file then renames — readers never see a
+    partial file. Verify the .tmp path doesn't linger after success."""
+    path, _ = _write_manifest(tmp_path)
+    assert os.path.exists(path)
+    assert not os.path.exists(path + ".tmp")
+
+
+def test_init_template_overwrite_protection(tmp_path):
+    """Calling init_template twice without overwrite=True raises FileExistsError."""
+    path, _ = _write_manifest(tmp_path)
+    # init_template is the public entry; mock the source-loading dependency.
+    # We can't easily run it without a real source, but we can verify the
+    # FileExistsError is raised when out_path exists.
+    recipe = tmp_path / "r.yaml"
+    recipe.write_text("directories:\n  zarr: /nope\n")
+    with pytest.raises(FileExistsError):
+        tranches.init_template(
+            recipe_path=str(recipe), num_tranches=2, mpi_batch_size=4,
+            out_path=path, overwrite=False,
+        )

--- a/ufs2arco/__init__.py
+++ b/ufs2arco/__init__.py
@@ -5,6 +5,7 @@ except PackageNotFoundError:
     pass
 
 from .driver import Driver
+from . import tranches
 from .cice6dataset import CICE6Dataset
 from .fv3dataset import FV3Dataset
 from .layers2pressure import Layers2Pressure

--- a/ufs2arco/cli.py
+++ b/ufs2arco/cli.py
@@ -18,22 +18,66 @@ def main():
         action="store_true",
         help="Pass this flag to overwrite an existing zarr store in the specified location",
     )
-    
+
     parser.add_argument(
         "--validate",
         action="store_true",
-        help="Validate configs without saving data"
+        help="Validate configs without saving data",
     )
-    
+
+    parser.add_argument(
+        "--tranche",
+        type=int,
+        default=None,
+        help=(
+            "Run a specific tranche (0-indexed) from the tranche manifest at "
+            "<recipe-stem>.tranches.yaml. Bounds the batch loop to that tranche's "
+            "[start, stop) range and skips finalize. Generate the manifest with "
+            "`python -m ufs2arco.tranches init`."
+        ),
+    )
+
+    parser.add_argument(
+        "--finalize",
+        action="store_true",
+        help=(
+            "Skip ingest entirely; only run target.finalize() + finalize_attributes() "
+            "on the existing zarr. Errors if any tranche is still pending (override with --force)."
+        ),
+    )
+
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Bypass safety checks (currently: --finalize on incomplete tranches).",
+    )
+
     args = parser.parse_args()
+
+    # Mutually-exclusive run modes.
+    if args.tranche is not None and args.finalize:
+        parser.error("--tranche and --finalize are mutually exclusive")
 
     with open(args.yaml_file, "r") as f:
         config = yaml.safe_load(f)
 
     if "multisource" in config.keys():
-        MultiDriver(args.yaml_file).run(overwrite=args.overwrite, validate=args.validate)
+        driver = MultiDriver(args.yaml_file)
+        driver.run(
+            overwrite=args.overwrite,
+            validate=args.validate,
+            tranche_id=args.tranche,
+            finalize_only=args.finalize,
+            force=args.force,
+        )
     else:
-        Driver(args.yaml_file).run(overwrite=args.overwrite)
+        driver = Driver(args.yaml_file)
+        driver.run(
+            overwrite=args.overwrite,
+            tranche_id=args.tranche,
+            finalize_only=args.finalize,
+            force=args.force,
+        )
 
 if __name__ == "__main__":
     main()

--- a/ufs2arco/datamover.py
+++ b/ufs2arco/datamover.py
@@ -44,6 +44,7 @@ class DataMover():
         batch_size,
         transformer=None,
         start=0,
+        stop=None,
         cache_dir=".",
     ):
 
@@ -52,6 +53,7 @@ class DataMover():
         self.transformer = transformer if transformer is not None else lambda xds: xds
         self.batch_size = batch_size
         self.start = start
+        self.stop = stop  # exclusive batch upper bound; None means run to end
         self.counter = start
         self.data_counter = start
         self.outer_cache_dir = cache_dir
@@ -273,6 +275,7 @@ class MPIDataMover(DataMover):
         mpi_topo,
         transformer=None,
         start=0,
+        stop=None,
         cache_dir=".",
     ):
         assert _has_mpi, f"{self.name}.__init__: Unable to import mpi4py, cannot use this class"
@@ -287,6 +290,7 @@ class MPIDataMover(DataMover):
             batch_size=batch_size,
             transformer=transformer,
             start=start,
+            stop=stop,
             cache_dir=cache_dir,
         )
         logger.info(str(self))

--- a/ufs2arco/driver.py
+++ b/ufs2arco/driver.py
@@ -21,6 +21,7 @@ import ufs2arco.sources
 from ufs2arco.transforms import Transformer
 import ufs2arco.targets
 from ufs2arco.datamover import DataMover, MPIDataMover
+from ufs2arco import tranches as _tranches
 
 logger = logging.getLogger("ufs2arco")
 
@@ -80,6 +81,10 @@ class Driver:
             AssertionError: If required sections or keys are missing in the configuration.
             NotImplementedError: If a source, target, or mover is not recognized.
         """
+        self.config_filename = config_filename
+        # tranche_id is set when the driver is run with --tranche=N; used to
+        # produce per-tranche missing.<zarr>.tranche_<N>.yaml files.
+        self.tranche_id = None
         with open(config_filename, "r") as f:
             self.config = yaml.safe_load(f)
         
@@ -258,18 +263,38 @@ class Driver:
         self.topo.barrier()
 
 
-    def run(self, overwrite: bool = False):
+    def run(
+        self,
+        overwrite: bool = False,
+        tranche_id: int = None,
+        finalize_only: bool = False,
+        force: bool = False,
+    ):
         """Runs the data movement process, managing the datasets and mover.
 
         This method sets up the datasets, creates the container, and loops through
         batches to move data to the specified store path (Zarr format).
 
         Args:
-            overwrite (bool, optional): Whether to overwrite the existing container.
-                Defaults to False.
+            overwrite: Whether to overwrite the existing container. Allowed only
+                in single-shot mode or with ``tranche_id=0``.
+            tranche_id: If set, run only the batch range listed for that tranche
+                in the tranche manifest at <recipe-stem>.tranches.yaml. The batch
+                loop is bounded by [tranche.start, tranche.stop) and finalize is
+                skipped — the user must run ``--finalize`` after all tranches done.
+            finalize_only: Skip the batch loop entirely; only run target.finalize()
+                and finalize_attributes() on the existing zarr.
+            force: Bypass safety checks (e.g., finalize-with-pending-tranches).
         """
-        
+        if finalize_only:
+            self._run_finalize_only(force=force)
+            return
+
         self.setup(runtype="create")
+
+        # tranche-specific overrides
+        if tranche_id is not None:
+            self._apply_tranche(tranche_id, overwrite=overwrite)
 
         # create container, only if mover start is not 0
         if self.mover.start == 0:
@@ -277,44 +302,165 @@ class Driver:
 
         # loop through batches
         n_batches = len(self.mover)
+        upper = (
+            min(n_batches, self.mover.stop)
+            if self.mover.stop is not None
+            else n_batches
+        )
         missing_dims = []
-        for batch_idx in range(self.mover.start, n_batches):
+        try:
+            for batch_idx in range(self.mover.start, upper):
 
-            xds = next(self.mover)
+                xds = next(self.mover)
 
-            # xds is None if MPI rank looks for non existent indices (i.e., last batch scenario)
-            # len(xds) == 0 if we couldn't find the file we were looking for
-            has_content = xds is not None and len(xds) > 0
-            if has_content:
+                # xds is None if MPI rank looks for non existent indices (i.e., last batch scenario)
+                # len(xds) == 0 if we couldn't find the file we were looking for
+                has_content = xds is not None and len(xds) > 0
+                if has_content:
 
-                xds = xds.reset_coords(drop=True)
-                region = self.mover.find_my_region(xds)
-                try:
-                    xds.to_zarr(self.store_path, region=region)
-                except Exception as e:
-                    print(f"\n {xds=}")
-                    traceback.print_exc()
-                    break 
-                self.mover.clear_cache(batch_idx)
+                    xds = xds.reset_coords(drop=True)
+                    region = self.mover.find_my_region(xds)
+                    try:
+                        xds.to_zarr(self.store_path, region=region)
+                    except Exception as e:
+                        print(f"\n {xds=}")
+                        traceback.print_exc()
+                        break
+                    self.mover.clear_cache(batch_idx)
 
-            elif xds is not None:
+                elif xds is not None:
 
-                # we couldn't find the file, keep track of it
-                batch_indices = self.mover.get_batch_indices(batch_idx)
-                for these_dims in batch_indices:
-                    # Enrich with valid_time if available in dataset attrs
-                    these_dims_enriched = these_dims.copy()
-                    if hasattr(xds, 'attrs') and 'valid_time' in xds.attrs:
-                        these_dims_enriched['valid_time'] = xds.attrs['valid_time']
-                    missing_dims.append(these_dims_enriched)
+                    # we couldn't find the file, keep track of it
+                    batch_indices = self.mover.get_batch_indices(batch_idx)
+                    for these_dims in batch_indices:
+                        # Enrich with valid_time if available in dataset attrs
+                        these_dims_enriched = these_dims.copy()
+                        if hasattr(xds, 'attrs') and 'valid_time' in xds.attrs:
+                            these_dims_enriched['valid_time'] = xds.attrs['valid_time']
+                        missing_dims.append(these_dims_enriched)
 
-            logger.info(f"Done with batch {batch_idx+1} / {n_batches}")
+                logger.info(f"Done with batch {batch_idx+1} / {n_batches}")
+        except Exception:
+            # Mark the tranche failed so the manifest reflects reality.
+            if tranche_id is not None:
+                self._mark_tranche_done(tranche_id, state="failed")
+            raise
 
         self.topo.barrier()
         logger.info(f"Done moving the data\n")
 
         self.report_missing_data(missing_dims)
-        
+
+        if tranche_id is None:
+            # Single-shot run: finalize as usual.
+            self.target.finalize(self.topo)
+            self.finalize_attributes()
+        else:
+            # Tranche run: skip finalize. Mark this tranche done.
+            self._mark_tranche_done(tranche_id, state="done")
+            logger.info(
+                f"Tranche {tranche_id} complete. Finalize is deferred — run "
+                f"`ufs2arco {self.config_filename} --finalize` once all tranches are done."
+            )
+
+    # ------------------------------------------------------------------
+    # tranche / finalize helpers
+    # ------------------------------------------------------------------
+    def _apply_tranche(self, tranche_id: int, overwrite: bool):
+        """Load the tranche manifest, override mover.start/stop, mark running."""
+        manifest_path = _tranches.default_tranche_path(self.config_filename)
+        if not os.path.exists(manifest_path):
+            raise FileNotFoundError(
+                f"--tranche={tranche_id} but no tranche manifest at {manifest_path}.\n"
+                f"Generate one with: python -m ufs2arco.tranches init "
+                f"{self.config_filename} --num-tranches N --mpi-batch-size B"
+            )
+        manifest = _tranches.load_manifest(manifest_path, recipe_path=self.config_filename)
+        tranche = _tranches.get_tranche(manifest, tranche_id)
+
+        # Sanity: batch_size at runtime must match the manifest's recorded
+        # batch_size, otherwise [start, stop) maps to different samples.
+        runtime_bs = self.mover.batch_size
+        manifest_bs = manifest["batch_size"]
+        if runtime_bs != manifest_bs:
+            raise RuntimeError(
+                f"Tranche manifest assumes batch_size={manifest_bs} but the "
+                f"current run is using batch_size={runtime_bs}. Re-run with the "
+                f"same MPI rank count, or regenerate the manifest with the new "
+                f"batch size."
+            )
+
+        # Guard against accidental container truncation on later tranches.
+        if overwrite and tranche["start"] != 0:
+            raise ValueError(
+                f"--overwrite is allowed only with tranche 0 (start=0). "
+                f"Tranche {tranche_id} starts at batch {tranche['start']}."
+            )
+
+        self.tranche_id = tranche_id
+        self.mover.start = tranche["start"]
+        self.mover.stop = tranche["stop"]
+        self.mover.counter = tranche["start"]
+        self.mover.data_counter = tranche["start"]
+        self.mover.restart(idx=tranche["start"])
+        self._tranche_manifest_path = manifest_path
+
+        if self.topo.is_root:
+            _tranches.update_state(
+                manifest_path,
+                tranche_id,
+                state="running",
+                started_utc=datetime.utcnow().isoformat() + "Z",
+                finished_utc=None,
+            )
+
+    def _mark_tranche_done(self, tranche_id: int, state: str = "done"):
+        """Update the tranche state in the manifest from rank 0."""
+        if not self.topo.is_root:
+            return
+        path = getattr(self, "_tranche_manifest_path", None)
+        if path is None:
+            return
+        try:
+            _tranches.update_state(
+                path,
+                tranche_id,
+                state=state,
+                finished_utc=datetime.utcnow().isoformat() + "Z",
+            )
+        except Exception as e:
+            logger.warning(f"Failed to update tranche manifest state: {e}")
+
+    def _run_finalize_only(self, force: bool = False):
+        """Skip ingest entirely; run target.finalize() + finalize_attributes()
+        on the populated zarr.
+        """
+        self.setup(runtype="finalize")
+
+        # If a tranche manifest exists, verify all tranches are done (or --force).
+        manifest_path = _tranches.default_tranche_path(self.config_filename)
+        if os.path.exists(manifest_path):
+            try:
+                manifest = _tranches.load_manifest(
+                    manifest_path, recipe_path=self.config_filename,
+                )
+                ok, pending = _tranches.verify_complete(manifest)
+                if not ok:
+                    msg = (
+                        f"--finalize: {len(pending)} tranche(s) are not done: "
+                        f"{pending}. Run them first, or pass --force to "
+                        f"finalize anyway."
+                    )
+                    if force:
+                        logger.warning(msg + " (forcing)")
+                    else:
+                        raise RuntimeError(msg)
+            except RuntimeError:
+                raise
+            except Exception as e:
+                logger.warning(f"Tranche manifest unreadable; proceeding: {e}")
+
+        logger.info(f"Driver._run_finalize_only: finalizing {self.store_path}")
         self.target.finalize(self.topo)
         self.finalize_attributes()
 
@@ -385,7 +531,12 @@ class Driver:
         # Handle relative paths (directory could be empty string)
         if not directory:
             directory = "."
-        return f"{directory}/missing.{zstore}.yaml"
+        # Per-tranche files preserve missing-data state across sessions —
+        # without this each tranche would clobber the prior tranche's record.
+        suffix = ""
+        if getattr(self, "tranche_id", None) is not None:
+            suffix = f".tranche_{self.tranche_id}"
+        return f"{directory}/missing.{zstore}{suffix}.yaml"
 
     def report_missing_data(self, missing_dims):
 

--- a/ufs2arco/multidriver.py
+++ b/ufs2arco/multidriver.py
@@ -32,6 +32,7 @@ from ufs2arco import targets
 from ufs2arco.datamover import DataMover, MPIDataMover
 
 from ufs2arco.driver import Driver
+from ufs2arco import tranches as _tranches
 
 logger = logging.getLogger("ufs2arco")
 
@@ -196,19 +197,44 @@ class MultiDriver(Driver):
         self.topo.barrier()
 
 
-    def run(self, overwrite: bool = False, validate: bool = False):
+    def run(
+        self,
+        overwrite: bool = False,
+        validate: bool = False,
+        tranche_id: int = None,
+        finalize_only: bool = False,
+        force: bool = False,
+    ):
         """Runs the data movement process, managing the datasets and mover.
 
-        This method sets up the datasets, creates the container, and loops through
-        batches to move data to the specified store path (Zarr format).
-
         Args:
-            overwrite (bool, optional): Whether to overwrite the existing container.
-                Defaults to False.
-            validate (bool, optional): If true, validate the configs, but 
-                without saving data. Defaults to False
+            overwrite: Whether to overwrite the existing container. Allowed only
+                in single-shot mode or with ``tranche_id=0``.
+            validate: If true, validate the configs without saving data.
+            tranche_id: If set, run only the batch range listed for that tranche
+                in the tranche manifest at <recipe-stem>.tranches.yaml. The batch
+                loop is bounded by [tranche.start, tranche.stop) and finalize is
+                skipped — the user must run ``--finalize`` after all tranches done.
+            finalize_only: Skip the batch loop entirely; only run target.finalize()
+                and finalize_attributes() on the existing zarr.
+            force: Bypass safety checks (e.g., finalize-with-pending-tranches).
         """
+        if finalize_only:
+            self._run_finalize_only(force=force)
+            return
+
         self.setup(runtype="create")
+
+        # tranche-specific overrides — apply to ALL movers since the multidriver
+        # iterates each per batch.
+        if tranche_id is not None:
+            self._apply_tranche(tranche_id, overwrite=overwrite)
+            for m in self.movers[1:]:
+                m.start = self.mover.start
+                m.stop = self.mover.stop
+                m.counter = self.mover.start
+                m.data_counter = self.mover.start
+                m.restart(idx=self.mover.start)
 
         # create container, only if mover start is not 0
         if self.mover.start == 0:
@@ -216,52 +242,68 @@ class MultiDriver(Driver):
 
         # loop through batches
         n_batches = len(self.mover)
+        upper = (
+            min(n_batches, self.mover.stop)
+            if self.mover.stop is not None
+            else n_batches
+        )
         missing_dims = []
-        for batch_idx in range(self.mover.start, n_batches):
+        try:
+            for batch_idx in range(self.mover.start, upper):
 
-            dslist = list()
-            foundit = list()
-            for mover in self.movers:
+                dslist = list()
+                foundit = list()
+                for mover in self.movers:
 
-                xds = next(mover)
+                    xds = next(mover)
 
-                # xds is None if MPI rank looks for non existent indices (i.e., last batch scenario)
-                # len(xds) == 0 if we couldn't find the file we were looking for
-                has_content = xds is not None and len(xds) > 0
-                if has_content:
-                    foundit.append(True)
-                    dslist.append(xds.reset_coords(drop=True))
+                    has_content = xds is not None and len(xds) > 0
+                    if has_content:
+                        foundit.append(True)
+                        dslist.append(xds.reset_coords(drop=True))
 
-                elif xds is not None:
+                    elif xds is not None:
 
-                    foundit.append(False)
-                    batch_indices = mover.get_batch_indices(batch_idx)
-                    for these_dims in batch_indices:
-                        # Enrich with valid_time if available in dataset attrs
-                        these_dims_enriched = these_dims.copy()
-                        if hasattr(xds, 'attrs') and 'valid_time' in xds.attrs:
-                            these_dims_enriched['valid_time'] = xds.attrs['valid_time']
-                        missing_dims.append(these_dims_enriched)
+                        foundit.append(False)
+                        batch_indices = mover.get_batch_indices(batch_idx)
+                        for these_dims in batch_indices:
+                            these_dims_enriched = these_dims.copy()
+                            if hasattr(xds, 'attrs') and 'valid_time' in xds.attrs:
+                                these_dims_enriched['valid_time'] = xds.attrs['valid_time']
+                            missing_dims.append(these_dims_enriched)
 
-            # we need both conditionals, since all([]) == True
-            if all(foundit) and len(foundit) == len(self.movers):
-                mds = self.target.merge_multisource(dslist)
-                region = self.mover.find_my_region(mds)
-                if not validate:
-                    # Use ProgressBar for the zarr write operation
-                    mds.to_zarr(self.target.store_path, region=region)
+                # we need both conditionals, since all([]) == True
+                if all(foundit) and len(foundit) == len(self.movers):
+                    mds = self.target.merge_multisource(dslist)
+                    region = self.mover.find_my_region(mds)
+                    if not validate:
+                        mds.to_zarr(self.target.store_path, region=region)
 
-            self.mover.clear_cache(batch_idx)
+                self.mover.clear_cache(batch_idx)
 
-            logger.info(f"Done with batch {batch_idx+1} / {n_batches}")
+                logger.info(f"Done with batch {batch_idx+1} / {n_batches}")
+        except Exception:
+            if tranche_id is not None:
+                self._mark_tranche_done(tranche_id, state="failed")
+            raise
 
         self.topo.barrier()
         logger.info(f"Done moving the data\n")
 
-        if not validate:
-            self.report_missing_data(missing_dims)
+        if validate:
+            return
+
+        self.report_missing_data(missing_dims)
+
+        if tranche_id is None:
             self.target.finalize(self.topo)
             self.finalize_attributes()
+        else:
+            self._mark_tranche_done(tranche_id, state="done")
+            logger.info(
+                f"Tranche {tranche_id} complete. Finalize is deferred — run "
+                f"`ufs2arco {self.config_filename} --finalize` once all tranches are done."
+            )
 
     def patch(self):
         raise NotImplementedError

--- a/ufs2arco/sources/aws_graf_regridded_patches.py
+++ b/ufs2arco/sources/aws_graf_regridded_patches.py
@@ -4,7 +4,7 @@ Reads the same S3 zarrs as :class:`AWSGRAFRegriddedArchive` but produces
 many short (3-frame) trajectories per case instead of one long per-init
 trajectory. Each trajectory is a 1000×1000 km spatial patch sampled from
 a manifest that was built ahead of time by
-``grafai/datasets/graf-regridded-conus-patches/scripts/build_patch_manifest.py``.
+``grafai/datasets/patch_sampler/build_patch_manifest.py``.
 
 Key differences from the parent class
 -------------------------------------
@@ -37,15 +37,20 @@ centers ahead of the main dataset build.
 """
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
+import re
 from typing import Literal, Optional
 
 import netCDF4  # noqa: F401 — parent class imports
 import numpy as np
 import pandas as pd
 import xarray as xr
+
+# Manifests may carry replica suffixes (``<case_str>@r<n>``) so that the same
+# underlying case can contribute several instances with distinct random
+# start-offsets + patches (precip-rank upsampling). Strip before URL lookup.
+_REPLICA_SUFFIX = re.compile(r"@r\d+$")
 
 from ufs2arco.sources import Source
 from ufs2arco.sources.aws_graf_reforecast_regridded import AWSGRAFRegriddedArchive
@@ -58,20 +63,16 @@ from ufs2arco.transforms.temporal_aggregation import temporal_aggregation
 
 logger = logging.getLogger("ufs2arco")
 
-# HRRR 4 km Lambert Conformal grid pixel size (km)
+# GRAF regridded 4 km Lambert Conformal grid pixel size (km).
+# Not HRRR's LC — GRAF uses its own projection; the 4 km pixel size happens
+# to match HRRR's, so the pixel-km math is the same.
 _PIXEL_KM = 4.0
 
 
-def _trajectory_id_to_int(s: str) -> int:
-    """Deterministic 63-bit positive int from a trajectory_id string.
-
-    The manifest stores trajectory_id as a human-readable
-    "<case>:<start_offset>:<patch_idx>" string. The final zarr stores
-    trajectory_ids as int64. This maps the string → int stably so the
-    same manifest always yields the same integer IDs.
-    """
-    h = hashlib.md5(s.encode()).digest()[:8]
-    return int.from_bytes(h, "big") & 0x7FFFFFFFFFFFFFFF
+# Trajectory IDs are assigned as sequential small ints (matches the Oklahoma
+# dataset convention via np.repeat(np.arange(n_init), n_steps)). The
+# human-readable "<case>:<start_offset>:<patch_idx>" string is preserved
+# in self.trajectory_id_dict for inspection.
 
 
 class AWSGRAFRegriddedPatchesArchive(AWSGRAFRegriddedArchive):
@@ -84,6 +85,11 @@ class AWSGRAFRegriddedPatchesArchive(AWSGRAFRegriddedArchive):
 
     # Same sample-dim convention as the parent — DataMover iteration unchanged.
     sample_dims = ("init_time", "forecast_step")
+
+    # Each sample is a different spatial slice → static vars (ter, landmask,
+    # per-patch lat/lon) differ across samples even though their tendency
+    # within a trajectory is 0. See Source.statics_vary_per_sample docstring.
+    statics_vary_per_sample = True
 
     def __init__(
         self,
@@ -222,6 +228,15 @@ class AWSGRAFRegriddedPatchesArchive(AWSGRAFRegriddedArchive):
     def name(self) -> str:
         return "AWSGRAFRegriddedPatchesArchive"
 
+    def _build_path(self, init_time: str) -> str:
+        """Build the zarr URL, stripping any ``@r<n>`` replica suffix.
+
+        Case replicas share the same underlying data — only the random
+        start-offsets and patch centers differ across replicas.
+        """
+        case_str = _REPLICA_SUFFIX.sub("", init_time)
+        return f"{self.BUCKET}{case_str}/mpasout_{self.file_freqstr}.zarr"
+
     # ------------------------------------------------------------------
     # Iteration: forecast_step enumerates (patch_idx × n_frames) per init
     # ------------------------------------------------------------------
@@ -241,7 +256,11 @@ class AWSGRAFRegriddedPatchesArchive(AWSGRAFRegriddedArchive):
 
         all_valid_times: list[pd.Timestamp] = []
         all_traj_ids: list[int] = []
+        # Sequential small-int IDs (matches the Oklahoma dataset convention).
+        # Keep the human-readable string mapping for inspection / tracing back
+        # to the manifest entry.
         self.trajectory_id_dict: dict[str, int] = {}
+        next_int_id = 0
 
         for init_time in self.init_time:
             init_dt = self._init_time_dt_map[init_time]
@@ -249,7 +268,8 @@ class AWSGRAFRegriddedPatchesArchive(AWSGRAFRegriddedArchive):
             for patch_idx_slot in range(self.n_patches_per_init):
                 entry = entries[patch_idx_slot]
                 traj_id_str: str = entry["trajectory_id"]
-                traj_id_int = _trajectory_id_to_int(traj_id_str)
+                traj_id_int = next_int_id
+                next_int_id += 1
                 self.trajectory_id_dict[traj_id_str] = traj_id_int
 
                 start_off_td = pd.Timedelta(minutes=int(entry["start_offset_min"]))
@@ -278,21 +298,28 @@ class AWSGRAFRegriddedPatchesArchive(AWSGRAFRegriddedArchive):
         at (lat_c, lon_c) in the HRRR grid's lat/lon convention.
 
         Uses nearest-pixel matching + ``patch_size_pix / 2`` half-width.
-        Patches that span the grid edge are clipped (may be smaller than
-        nominal); the manifest builder's bbox avoids edge cases for the
-        default CONUS bbox.
+        If the nominal slice would run off the grid edge, the slice is
+        SHIFTED INWARD so the full ``(patch_size_pix, patch_size_pix)``
+        window always fits. This keeps sample shape uniform (required
+        by the downstream zarr writer) at the cost of shifting edge
+        patches by up to ``half`` pixels; the stored per-patch lat/lon
+        reflect the actual (shifted) center, so downstream consumers
+        see the real location of the data, not the manifest's intent.
         """
         lat_2d = self.lat_lon["latitude"][-1]    # (y, x)
         lon_2d = self.lat_lon["longitude"][-1]   # in 360° convention
+        H, W = lat_2d.shape
         # Convert input lon to 360° for matching
         lon_match = lon_c if lon_c >= 0 else lon_c + 360.0
         d2 = (lat_2d - lat_c) ** 2 + (lon_2d - lon_match) ** 2
         y_c, x_c = np.unravel_index(int(np.argmin(d2)), d2.shape)
         half = self.patch_size_pix // 2
-        y_lo = max(0, y_c - half)
-        y_hi = min(lat_2d.shape[0], y_c + half)
-        x_lo = max(0, x_c - half)
-        x_hi = min(lat_2d.shape[1], x_c + half)
+        # Clamp the low-corner so [y_lo, y_lo + patch_size_pix) is fully
+        # inside [0, H). Same for x.
+        y_lo = max(0, min(H - self.patch_size_pix, y_c - half))
+        y_hi = y_lo + self.patch_size_pix
+        x_lo = max(0, min(W - self.patch_size_pix, x_c - half))
+        x_hi = x_lo + self.patch_size_pix
         return slice(int(y_lo), int(y_hi)), slice(int(x_lo), int(x_hi))
 
     def get_valid_time(self, xds: xr.Dataset, **dims) -> pd.Timestamp:
@@ -404,5 +431,14 @@ class AWSGRAFRegriddedPatchesArchive(AWSGRAFRegriddedArchive):
         xds.attrs["patch_center_lon"] = float(entry["lon_c"])
         xds.attrs["patch_source"] = entry["source"]
         xds.attrs["trajectory_id_str"] = entry["trajectory_id"]
+
+        # CRITICAL: Many patches within a single (case, start) share the SAME
+        # valid_time (they're time-aligned, differ only spatially), which would
+        # collide onto one output time slot via the target's default
+        # valid_time-based indexing. Set _sample_index so the Anemoi target
+        # uses our flat sample position as the time-axis index — same hook
+        # WoFSCast uses for ensemble members sharing valid_times.
+        init_idx = self.init_time.index(init_time)
+        xds.attrs["_sample_index"] = init_idx * self.n_steps + forecast_step
 
         return xds

--- a/ufs2arco/sources/base.py
+++ b/ufs2arco/sources/base.py
@@ -19,6 +19,13 @@ class Source:
     available_variables = tuple()
     available_levels = tuple()
 
+    # Set True when the source-declared static variables (ter, landmask, …)
+    # vary across samples — e.g. a patch-based source where each sample is
+    # a different spatial slice. In that case the anemoi writer must not
+    # let anemoi.datasets auto-classify those variables as constant_in_time
+    # (their within-sample tendency is 0, which the auto-detector misreads).
+    statics_vary_per_sample: bool = False
+
     @property
     def rename(self) -> dict:
         """

--- a/ufs2arco/sources/graf_utils.py
+++ b/ufs2arco/sources/graf_utils.py
@@ -60,7 +60,7 @@ def _raymond_apply_axis_batched(arr: np.ndarray, axis: int, eps: float) -> np.nd
     return np.transpose(y, perm)           # un-swap — same perm is self-inverse
 
 
-def raymond_filter_2d(field_2d, eps=0.5, order=6):
+def raymond_filter_2d(field_2d, eps=0.5, order=6, pad=8, pad_mode="reflect"):
     """Vectorized Raymond (1988) implicit tangent low-pass filter in both
     spatial directions. Accepts ``(..., ny, nx)`` with arbitrary leading
     batch dims — level / variable / ensemble all handled in a single
@@ -76,18 +76,39 @@ def raymond_filter_2d(field_2d, eps=0.5, order=6):
     order : int
         Filter order (2, 4, or 6). Achieved by repeated application of
         the 2nd-order filter. Higher order = sharper spectral cutoff.
+    pad : int
+        Number of cells of padding to apply on each side of the (y, x)
+        plane before filtering. Trimmed back to the original shape after.
+        The implicit filter has zero-Dirichlet-like boundary behavior in
+        ``solve_banded``, which produces a ringing artifact in the outer
+        ~``order`` cells (e.g. ~108 K t2m on what should be ~290 K).
+        Padding by ``order + 2`` cells with mirroring shifts the artifact
+        into the discarded padded region. Set ``pad=0`` to recover the
+        legacy (artifact-prone) behavior for backward-compat tests.
+    pad_mode : str
+        Anything accepted by :func:`numpy.pad`. ``"reflect"`` mirrors
+        across the boundary cell (no duplication) — preserves the mean
+        and the gradient continuity for atmospheric fields.
     """
     n_passes = order // 2
-    result = field_2d.astype(np.float64)
+    if pad > 0:
+        pad_width = [(0, 0)] * (field_2d.ndim - 2) + [(pad, pad), (pad, pad)]
+        result = np.pad(field_2d, pad_width, mode=pad_mode).astype(np.float64)
+    else:
+        result = field_2d.astype(np.float64)
     for _ in range(n_passes):
         # Filter along x (last axis)
         result = _raymond_apply_axis_batched(result, axis=-1, eps=eps)
         # Filter along y (second-to-last axis)
         result = _raymond_apply_axis_batched(result, axis=-2, eps=eps)
+    if pad > 0:
+        sl = (slice(None),) * (field_2d.ndim - 2) + (slice(pad, -pad), slice(pad, -pad))
+        result = result[sl]
     return result.astype(np.float32)
 
 
-def apply_raymond_filter_to_dataset(xds, eps=0.5, order=6, level_dim='level'):
+def apply_raymond_filter_to_dataset(xds, eps=0.5, order=6, level_dim='level',
+                                    pad=8, pad_mode="reflect"):
     """Apply Raymond filter to all 3D variables in an xarray Dataset.
 
     Filters each 2D (y, x) slice at each vertical level independently.
@@ -103,13 +124,33 @@ def apply_raymond_filter_to_dataset(xds, eps=0.5, order=6, level_dim='level'):
         Filter order (2, 4, or 6).
     level_dim : str
         Name of the vertical level dimension.
+    pad, pad_mode :
+        Forwarded to :func:`raymond_filter_2d` for boundary handling.
+        Defaults (8 cells, reflect) suppress the ringing artifact at
+        each (y, x) edge of the filtered slice.
 
     Returns
     -------
     xr.Dataset with filtered data variables.
     """
-    # Variables to skip (static, coordinate-like, or 2D)
-    skip_vars = {'latitude', 'longitude', 'surface_elevation', 'land_sea_mask'}
+    # Variables to skip — coordinates and every static field that may live
+    # in the regridded static NetCDF (post-rename names from
+    # AWSGRAFArchive.STATIC_VAR_RENAMER plus pass-through names for fields
+    # without a rename). Static fields are time-invariant by definition,
+    # so spatial smoothing has no scientific motivation and can corrupt
+    # categorical fields (vegetation/soil type) outright.
+    skip_vars = {
+        # coords
+        'latitude', 'longitude',
+        # renamed
+        'surface_elevation', 'land_sea_mask', 'climo_soiltemp',
+        'subgrid_terrain_variance', 'terrain_convexity',
+        'orographic_asymmetry_we', 'orographic_asymmetry_sn',
+        'orographic_asymmetry_swne', 'orographic_asymmetry_nwse',
+        # pass-through (no entry in STATIC_VAR_RENAMER)
+        'ivgtyp', 'isltyp', 'snoalb', 'greenfrac', 'shdmin', 'shdmax',
+        'albedo12m', 'varsso', 'ol1', 'ol2', 'ol3', 'ol4',
+    }
 
     updates = {}
     for var_name in xds.data_vars:
@@ -134,7 +175,8 @@ def apply_raymond_filter_to_dataset(xds, eps=0.5, order=6, level_dim='level'):
         if np.isnan(vals).any():
             continue
 
-        filtered = raymond_filter_2d(vals, eps=eps, order=order)
+        filtered = raymond_filter_2d(vals, eps=eps, order=order,
+                                     pad=pad, pad_mode=pad_mode)
         # Move (y, x) back to their original positions
         filtered = np.moveaxis(filtered, (-2, -1), (y_axis, x_axis))
 

--- a/ufs2arco/targets/anemoi.py
+++ b/ufs2arco/targets/anemoi.py
@@ -607,7 +607,33 @@ class Anemoi(Target):
             logger.info(f"Computing spectral + gradient statistics")
             self.calc_spectral_gradient_stats(topo)
             logger.info(f"Done computing spectral + gradient statistics\n")
-    
+
+        if topo.is_root and getattr(self.source, "statics_vary_per_sample", False):
+            self._write_empty_constant_fields()
+
+        topo.barrier()
+
+    def _write_empty_constant_fields(self) -> None:
+        """Stamp an empty ``constant_fields`` list on the zarr root.
+
+        Required for sources where static vars (ter, landmask, per-patch
+        lat/lon) vary across samples. Without this, anemoi.datasets'
+        ``_compute_constant_fields_from_statistics`` misclassifies them
+        as constant (their tendency stdev within a trajectory is 0), and
+        ``typed_variables`` then stamps ``constant_in_time=True`` on them.
+        Writing an explicit empty list short-circuits the auto-detector in
+        ``anemoi/datasets/data/stores.py``'s ``constant_fields`` property
+        (which only recomputes if the attr is ``None``).
+        """
+        import zarr as z
+
+        g = z.open_group(str(self.store_path), mode="a")
+        g.attrs["constant_fields"] = []
+        logger.info(
+            f"{self.name}._write_empty_constant_fields: stamped constant_fields=[] "
+            f"on {self.store_path} (source.statics_vary_per_sample=True)"
+        )
+
     def add_trajectory_ids(self)->None:
         """
         Add the unique trajectory ids for each model init

--- a/ufs2arco/tranches.py
+++ b/ufs2arco/tranches.py
@@ -1,0 +1,243 @@
+"""Tranche manifest helpers for multi-session ufs2arco builds.
+
+A tranche manifest enumerates fixed `[start, stop)` batch ranges of an
+otherwise single-shot ufs2arco build, so the user can ingest data in
+sessions (e.g., when source data is staged 100-200 TB at a time).
+
+Each session runs `ufs2arco recipe.yaml --tranche=N`; the driver looks
+up tranche N's batch range and ingests only that subset, skipping
+finalize. After all tranches are `done`, the user runs
+`ufs2arco recipe.yaml --finalize` to compute statistics over the full
+zarr. Re-running the same tranche is idempotent — `to_zarr(region=...)`
+silently overwrites chunks.
+
+Manifest path convention: alongside the recipe yaml, with `.tranches.yaml`
+appended (e.g., `build.yaml` -> `build.tranches.yaml`).
+"""
+import argparse
+import hashlib
+import itertools
+import os
+from datetime import datetime
+from math import ceil
+
+import yaml
+
+
+VALID_STATES = ("pending", "running", "done", "failed")
+
+
+def default_tranche_path(recipe_path: str) -> str:
+    """Tranche manifest path next to the recipe yaml."""
+    base, _ = os.path.splitext(recipe_path)
+    return f"{base}.tranches.yaml"
+
+
+def hash_recipe(recipe_path: str) -> str:
+    """SHA-256 of the raw recipe-yaml bytes — drift detection between sessions."""
+    with open(recipe_path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def _instantiate_first_source(config: dict):
+    """Return the first source object — used to enumerate sample_indices."""
+    import ufs2arco.sources
+
+    if "multisource" in config:
+        src_cfg = config["multisource"][0]["source"]
+    else:
+        src_cfg = config["source"]
+    name = src_cfg["name"].lower()
+    SourceCls = getattr(ufs2arco.sources, ufs2arco.sources._recognized[name])
+    kw = {k: v for k, v in src_cfg.items() if k != "name"}
+    return SourceCls(**kw)
+
+
+def compute_total_samples(recipe_path: str) -> int:
+    """Build the source's sample-index cartesian product and return its length."""
+    with open(recipe_path) as f:
+        config = yaml.safe_load(f)
+    source = _instantiate_first_source(config)
+    iterations = [getattr(source, key) for key in source.sample_dims]
+    total = 1
+    for v in iterations:
+        total *= len(v)
+    return total
+
+
+def init_template(
+    recipe_path: str,
+    num_tranches: int,
+    mpi_batch_size: int,
+    out_path: str = None,
+    overwrite: bool = False,
+):
+    """Generate an initial tranche manifest with N evenly-split batch ranges.
+
+    Args:
+        recipe_path: path to the ufs2arco recipe yaml.
+        num_tranches: number of tranches to split the build into.
+        mpi_batch_size: MPI rank count that will be used during the actual
+            build (e.g., 576 for 6 nodes × 96 ranks). Tranche batch indices
+            are tied to this size — re-running with a different MPI size
+            will be rejected at runtime.
+        out_path: optional override for the output manifest path.
+        overwrite: if True, replace an existing manifest at out_path.
+
+    Returns:
+        (out_path, manifest_dict)
+    """
+    if out_path is None:
+        out_path = default_tranche_path(recipe_path)
+    if os.path.exists(out_path) and not overwrite:
+        raise FileExistsError(
+            f"Tranche manifest already exists at {out_path}. "
+            f"Pass --overwrite to replace it."
+        )
+    if num_tranches < 1:
+        raise ValueError(f"num_tranches must be >= 1, got {num_tranches}")
+    if mpi_batch_size < 1:
+        raise ValueError(f"mpi_batch_size must be >= 1, got {mpi_batch_size}")
+
+    total_samples = compute_total_samples(recipe_path)
+    total_batches = ceil(total_samples / mpi_batch_size)
+
+    if num_tranches > total_batches:
+        raise ValueError(
+            f"Asked for {num_tranches} tranches but the build has only "
+            f"{total_batches} batches at batch_size={mpi_batch_size}."
+        )
+
+    base = total_batches // num_tranches
+    rem = total_batches % num_tranches
+    cursor = 0
+    tranches = []
+    for i in range(num_tranches):
+        size = base + (1 if i < rem else 0)
+        tranches.append({
+            "id": i,
+            "start": cursor,
+            "stop": cursor + size,
+            "description": f"tranche {i}",
+            "state": "pending",
+            "samples_processed": None,
+            "started_utc": None,
+            "finished_utc": None,
+        })
+        cursor += size
+
+    with open(recipe_path) as f:
+        recipe = yaml.safe_load(f)
+    zarr_path = recipe["directories"]["zarr"]
+
+    manifest = {
+        "zarr": zarr_path,
+        "config_hash": hash_recipe(recipe_path),
+        "total_samples": total_samples,
+        "total_batches": total_batches,
+        "batch_size": mpi_batch_size,
+        "created_utc": datetime.utcnow().isoformat() + "Z",
+        "tranches": tranches,
+    }
+    save_manifest(out_path, manifest)
+    return out_path, manifest
+
+
+def load_manifest(path: str, recipe_path: str = None) -> dict:
+    """Load and (optionally) verify the manifest matches the recipe hash."""
+    with open(path) as f:
+        manifest = yaml.safe_load(f)
+    if recipe_path is not None:
+        actual = hash_recipe(recipe_path)
+        if manifest.get("config_hash") != actual:
+            raise RuntimeError(
+                f"Recipe hash mismatch for {recipe_path}.\n"
+                f"  Manifest hash: {manifest.get('config_hash')}\n"
+                f"  Current hash:  {actual}\n"
+                f"YAML changes between tranches change batch-index semantics. "
+                f"If this change is intentional, regenerate the manifest with "
+                f"`python -m ufs2arco.tranches init`."
+            )
+    return manifest
+
+
+def save_manifest(path: str, manifest: dict) -> None:
+    """Atomic write via tmp file + rename."""
+    tmp = f"{path}.tmp"
+    with open(tmp, "w") as f:
+        yaml.safe_dump(manifest, f, sort_keys=False)
+    os.replace(tmp, path)
+
+
+def update_state(path: str, tranche_id: int, **fields) -> None:
+    """Update one tranche's fields. Atomic; intended to be called from rank 0 only."""
+    manifest = load_manifest(path)
+    for tr in manifest["tranches"]:
+        if tr["id"] == tranche_id:
+            for k, v in fields.items():
+                tr[k] = v
+            save_manifest(path, manifest)
+            return
+    raise KeyError(f"Tranche id {tranche_id} not found in {path}")
+
+
+def get_tranche(manifest: dict, tranche_id: int) -> dict:
+    for tr in manifest["tranches"]:
+        if tr["id"] == tranche_id:
+            return tr
+    raise KeyError(f"Tranche id {tranche_id} not found")
+
+
+def verify_complete(manifest: dict):
+    """Return (ok, pending_ids). ok=True iff every tranche is 'done'."""
+    pending = [tr["id"] for tr in manifest["tranches"] if tr["state"] != "done"]
+    return (len(pending) == 0, pending)
+
+
+def _main():
+    parser = argparse.ArgumentParser(
+        prog="python -m ufs2arco.tranches",
+        description="Tranche manifest tools for multi-session ufs2arco builds.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_init = sub.add_parser("init", help="Generate a tranche manifest template.")
+    p_init.add_argument("recipe", type=str, help="Path to the ufs2arco recipe yaml.")
+    p_init.add_argument("--num-tranches", type=int, required=True,
+                        help="Number of evenly-sized tranches to split the build into.")
+    p_init.add_argument("--mpi-batch-size", type=int, required=True,
+                        help="MPI rank count expected during builds (e.g., 576 for 6 nodes x 96).")
+    p_init.add_argument("--out", type=str, default=None,
+                        help="Output manifest path (default: <recipe-stem>.tranches.yaml).")
+    p_init.add_argument("--overwrite", action="store_true",
+                        help="Replace an existing manifest at the output path.")
+
+    p_show = sub.add_parser("show", help="Print summary of an existing manifest.")
+    p_show.add_argument("manifest", type=str)
+
+    args = parser.parse_args()
+    if args.cmd == "init":
+        out, manifest = init_template(
+            args.recipe, args.num_tranches, args.mpi_batch_size,
+            out_path=args.out, overwrite=args.overwrite,
+        )
+        print(f"Wrote {out}")
+        print(f"  total_samples = {manifest['total_samples']}")
+        print(f"  total_batches = {manifest['total_batches']} (batch_size = {manifest['batch_size']})")
+        for tr in manifest["tranches"]:
+            print(f"  tranche {tr['id']}: batches [{tr['start']}, {tr['stop']})  state={tr['state']}")
+    elif args.cmd == "show":
+        m = load_manifest(args.manifest)
+        ok, pending = verify_complete(m)
+        print(f"zarr:          {m['zarr']}")
+        print(f"config_hash:   {m['config_hash'][:16]}...")
+        print(f"total_samples: {m['total_samples']}")
+        print(f"total_batches: {m['total_batches']} (batch_size = {m['batch_size']})")
+        print(f"created_utc:   {m['created_utc']}")
+        print(f"tranches: ({len(m['tranches'])} total, {'all done' if ok else f'pending: {pending}'})")
+        for tr in m["tranches"]:
+            print(f"  {tr['id']:3d}: [{tr['start']:>7d}, {tr['stop']:>7d})  state={tr['state']:<8s}  {tr['description']}")
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
- New ufs2arco/tranches.py + tests: manifest helpers (init, load, state updates, completion check) for splitting a recipe into fixed [start, stop) batch ranges across sessions
- driver/multidriver: --tranche=N / --finalize / --force CLI flags; bounded batch loop via mover.stop; per-tranche state writes; defer finalize until all tranches done
- datamover: optional stop= upper bound on the batch iterator
- patches source: sequential int trajectory_ids, @r<n> replica suffix support, edge-patch shift-inward (uniform sample shape)
- misc: anemoi target / sources tweaks, script path fix